### PR TITLE
Feat: Add eager loading method `with`

### DIFF
--- a/src/AbstractRepository.php
+++ b/src/AbstractRepository.php
@@ -25,6 +25,11 @@ abstract class AbstractRepository implements Repository, RepositorySpecification
     /**
      * @var array
      */
+    protected $with = [];
+
+    /**
+     * @var array
+     */
     protected $specifications = [];
 
     /**
@@ -68,6 +73,10 @@ abstract class AbstractRepository implements Repository, RepositorySpecification
     protected function buildQuery()
     {
         $query = $this->model->newQuery();
+
+        if (count($this->with) > 0) {
+            $query = $query->with($this->with);
+        }
 
         foreach ($this->specifications as $specification) {
             $query = $specification->apply($query);
@@ -191,6 +200,17 @@ abstract class AbstractRepository implements Repository, RepositorySpecification
         }
 
         return $this->model->destroy($model);
+    }
+
+    /**
+     * @param  array  $with
+     * @return $this
+     */
+    public function with(array $with)
+    {
+        $this->with = $with;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Where previously users would have to settle on lazy loading, this
presents a problem when using the `cursor()` method. As Eloquent doesn't
allow you to lazy load relationships using a `LazyCollection`, it does
allow for eager loading. Thus I'm implementing a `with([...])` method to
satisfy the demand for eager loading relationships while fetching
records from the database using the `cursor()` method.